### PR TITLE
Update to support per task job executions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
 *.egg-info/
+/.python-version

--- a/bundle/orchestrate/dags/meltano.py
+++ b/bundle/orchestrate/dags/meltano.py
@@ -44,6 +44,122 @@ if not Path(project_root).joinpath(meltano_bin).exists():
     meltano_bin = "meltano"
 
 
+def _meltano_v1_generator(schedules):
+    """Generate singular dag's for each legacy Meltano elt task.
+
+    Args:
+        schedules (list): List of Meltano schedules.
+    """
+    for schedule in schedules:
+        logger.info(f"Considering schedule '{schedule['name']}': {schedule}")
+
+        if not schedule["cron_interval"]:
+            logger.info(
+                f"No DAG created for schedule '{schedule['name']}' because its interval is set to `@once`."
+            )
+            continue
+
+        args = DEFAULT_ARGS.copy()
+        if schedule["start_date"]:
+            args["start_date"] = schedule["start_date"]
+
+        dag_id = f"meltano_{schedule['name']}"
+
+        tags = DEFAULT_TAGS.copy()
+        if schedule["extractor"]:
+            tags.append(schedule["extractor"])
+        if schedule["loader"]:
+            tags.append(schedule["loader"])
+        if schedule["transform"] == "run":
+            tags.append("transform")
+        elif schedule["transform"] == "only":
+            tags.append("transform-only")
+
+        # from https://airflow.apache.org/docs/stable/scheduler.html#backfill-and-catchup
+        #
+        # It is crucial to set `catchup` to False so that Airflow only create a single job
+        # at the tail end of date window we want to extract data.
+        #
+        # Because our extractors do not support date-window extraction, it serves no
+        # purpose to enqueue date-chunked jobs for complete extraction window.
+        dag = DAG(
+            dag_id,
+            tags=tags,
+            catchup=False,
+            default_args=args,
+            schedule_interval=schedule["interval"],
+            max_active_runs=1,
+        )
+
+        elt = BashOperator(
+            task_id="extract_load",
+            bash_command=f"cd {project_root}; {meltano_bin} schedule run {schedule['name']}",
+            dag=dag,
+        )
+
+        # register the dag
+        globals()[dag_id] = dag
+
+        logger.info(f"DAG created for schedule '{schedule['name']}'")
+
+
+def _meltano_v2_job_generator(schedules):
+    """Generate dag's for each task within a Meltano scheduled job.
+
+    Args:
+        schedules (list): List of Meltano scheduled jobs.
+    """
+    for schedule in schedules:
+        if not schedule.get("job"):
+            logger.info(
+                f"No DAG's created for schedule '{schedule['name']}'. It was passed to job generator but has no job."
+            )
+            continue
+        if not schedule["cron_interval"]:
+            logger.info(
+                f"No DAG created for schedule '{schedule['name']}' because its interval is set to `@once`."
+            )
+            continue
+
+        base_id = f"meltano_{schedule['name']}_{schedule['job']['name']}"
+        common_tags = DEFAULT_TAGS.copy()
+        common_tags.append(schedule["job"]["name"])
+        for idx, task in enumerate(schedule["job"]["tasks"]):
+            logger.info(f"Considering task '{task}' of schedule '{schedule['name']}': {schedule}")
+            args = DEFAULT_ARGS.copy()
+
+            dag_id = f"{base_id}_task{idx}"
+
+            task_tags = common_tags.copy()
+
+            # from https://airflow.apache.org/docs/stable/scheduler.html#backfill-and-catchup
+            #
+            # It is crucial to set `catchup` to False so that Airflow only create a single job
+            # at the tail end of date window we want to extract data.
+            #
+            # Because our extractors do not support date-window extraction, it serves no
+            # purpose to enqueue date-chunked jobs for complete extraction window.
+            dag = DAG(
+                dag_id,
+                description=f"Meltano run task[{idx}]: '{task}'",
+                tags=task_tags,
+                catchup=False,
+                default_args=args,
+                schedule_interval=schedule["interval"],
+                max_active_runs=1,
+            )
+
+            elt = BashOperator(
+                task_id=task["name"],
+                bash_command=f"cd {project_root}; {meltano_bin} run {task}",
+                dag=dag,
+            )
+
+            # register the dag
+            globals()[dag_id] = dag
+            logger.info(f"Task DAG created for schedule '{schedule['name']}',Task='{task}' ")
+
+
 result = subprocess.run(
     [meltano_bin, "schedule", "list", "--format=json"],
     cwd=project_root,
@@ -53,54 +169,8 @@ result = subprocess.run(
 )
 schedules = json.loads(result.stdout)
 
-for schedule in schedules:
-    logger.info(f"Considering schedule '{schedule['name']}': {schedule}")
-
-    if not schedule["cron_interval"]:
-        logger.info(
-            f"No DAG created for schedule '{schedule['name']}' because its interval is set to `@once`."
-        )
-        continue
-
-    args = DEFAULT_ARGS.copy()
-    if schedule["start_date"]:
-        args["start_date"] = schedule["start_date"]
-
-    dag_id = f"meltano_{schedule['name']}"
-
-    tags = DEFAULT_TAGS.copy()
-    if schedule["extractor"]:
-        tags.append(schedule["extractor"])
-    if schedule["loader"]:
-        tags.append(schedule["loader"])
-    if schedule["transform"] == "run":
-        tags.append("transform")
-    elif schedule["transform"] == "only":
-        tags.append("transform-only")
-
-    # from https://airflow.apache.org/docs/stable/scheduler.html#backfill-and-catchup
-    #
-    # It is crucial to set `catchup` to False so that Airflow only create a single job
-    # at the tail end of date window we want to extract data.
-    #
-    # Because our extractors do not support date-window extraction, it serves no
-    # purpose to enqueue date-chunked jobs for complete extraction window.
-    dag = DAG(
-        dag_id,
-        tags=tags,
-        catchup=False,
-        default_args=args,
-        schedule_interval=schedule["interval"],
-        max_active_runs=1,
-    )
-
-    elt = BashOperator(
-        task_id="extract_load",
-        bash_command=f"cd {project_root}; {meltano_bin} schedule run {schedule['name']}",
-        dag=dag,
-    )
-
-    # register the dag
-    globals()[dag_id] = dag
-
-    logger.info(f"DAG created for schedule '{schedule['name']}'")
+if not (schedules.get("job") and schedules.get("elt")):
+    _meltano_v1_generator(schedules)
+else:
+    _meltano_v1_generator(schedules.get("elt"))
+    _meltano_v2_job_generator(schedules.get("job"))


### PR DESCRIPTION
 As part of meltano v2  the format/schema of `meltano schedule --list=format` changed to enable job support (https://github.com/meltano/meltano/pull/5923). This updates our dag generation to support scheduled jobs in addition to legacy ELT tasks. 

Rather than creating a single dag for a singular execution of the named job, we actually create a dag *per* task entry for the job. So given a job as follows:

```yaml
schedules:
- name: daily-doit
  interval: '@daily'
  job: simple-demo
- name: simple-demo
  tasks:
  - tap-gitlab hide-gitlab-secrets target-jsonl
  - tap-gitlab target-csv
```

We would create two dags:

1. `meltano run tap-gitlab hide-gitlab-secrets target-jsonl` (task0 in the screenshot)
2. `meltano run tap-gitlab target-csv` (task1 in the screenshot)

![Screen Shot 2022-06-02 at 11 24 01 AM](https://user-images.githubusercontent.com/333354/171678007-9b58e5f9-0872-453f-bc65-5b6719a35710.png)
![Screen Shot 2022-06-02 at 11 28 43 AM](https://user-images.githubusercontent.com/333354/171678839-dd84bd59-1f09-44d1-88e8-2ae47ea51527.png)

(labels/descriptions subject to change pending PR review)

closes https://github.com/meltano/files-airflow/issues/8


