### PR TITLE
One dag many tasks

### DIFF
--- a/bundle/orchestrate/dags/meltano.py
+++ b/bundle/orchestrate/dags/meltano.py
@@ -146,7 +146,7 @@ def _meltano_job_generator(schedules):
                 else:
                     run_args = task
 
-                run_task = BashOperator(
+                BashOperator(
                     task_id=task_id,
                     bash_command=f"cd {PROJECT_ROOT}; {MELTANO_BIN} run {run_args}",
                     dag=dag,


### PR DESCRIPTION
@tayloramurphy @aaronsteers @pnadolny13 is this more inline with what y'all would like ?

One dag two tasks:

![Screen Shot 2022-06-06 at 7 09 58 PM](https://user-images.githubusercontent.com/333354/172269218-13ab5965-2e4a-4312-80b1-484315c3c56c.png)

One dag, one task (because its flattened job):
![Screen Shot 2022-06-06 at 7 12 15 PM](https://user-images.githubusercontent.com/333354/172269451-8c74d35c-69e4-4e6f-9c75-e397c0678561.png)


That's based of this yaml:

```yaml
schedules:
- name: daily-doit
  interval: '@daily'
  job: simple-demo
- name: nested-example
  interval: '@hourly'
  job: nested
jobs:
- name: simple-demo
  tasks:
  - tap-gitlab hide-gitlab-secrets target-jsonl
  - tap-gitlab target-csv
- name: nested
  tasks:
  - - tap-gitlab hide-gitlab-secrets target-jsonl
    - tap-gitlab target-csv
```

