### PR TITLE
Bump version to 0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="files-airflow",
-    version="0.8",
+    version="0.9",
     description="Meltano project files for Airflow",
     packages=find_packages(),
     package_data={"bundle": ["orchestrate/dags/meltano.py"]},


### PR DESCRIPTION
Per https://github.com/meltano/files-airflow/issues/24, bumping the version to cut a updated release tag.